### PR TITLE
Handle arm type `armv7l` for node installation

### DIFF
--- a/setup/scripts/install-node.sh
+++ b/setup/scripts/install-node.sh
@@ -15,6 +15,12 @@ else
     NODE_MAJOR_VERSION="12"
     ARM=$(uname -m)
 
+    if [[ "$ARM" = "armv7l" ]]
+    then
+        echo "Original 'ARM' value is: $ARM, so using 'armv6l'"
+        ARM="armv6l"
+    fi
+
     info "Installing node"
 
     # node official debian distribution doesn't support ARM, so using unofficial distribution


### PR DESCRIPTION
Fixes https://github.com/pureartisan/magic-mirror-raspbian-lite/issues/1