### PR TITLE
Install custom xserverrc

### DIFF
--- a/setup/scripts/setup-xserver-on-startup.sh
+++ b/setup/scripts/setup-xserver-on-startup.sh
@@ -6,6 +6,9 @@ COMMENT_MM_RASP_LITE='#### Auto entry - Magic Mirror Raspbian Lite'
 XINITRC=~/.xinitrc
 XINITRC_BACKUP=~/.xinitrc.backup
 
+XSERVERRC=~/.xserverrc
+XSERVERRC_BACKUP=~/.xserverrc.backup
+
 BASHRC=~/.bashrc
 BASHRC_BACKUP=~/.bashrc.backup
 
@@ -31,6 +34,24 @@ sudo chmod a+x $XINITRC
 # add the entry point
 echo "# start app" >> $XINITRC
 echo "$MAGIC_MIRROR_APP_DIR/start-browser.sh" >> $XINITRC
+
+
+# -----------------------------------------------
+# changes to .xserverrc
+# -----------------------------------------------
+
+# create backup if file already exists
+if [ -f "$XSERVERRC" ]
+then
+    echo "File existing, so creating backup of $XSERVERRC"
+    cp $XSERVERRC $XSERVERRC_BACKUP
+fi
+
+info "Adding '$XSERVERRC' file..."
+
+# copy the xserverrc file
+cp $TEMPLATE_DIR/.xserverrc $XSERVERRC
+sudo chmod a+x $XSERVERRC
 
 
 # -----------------------------------------------

--- a/templates/.xserverrc
+++ b/templates/.xserverrc
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# based on /etc/X11/xinit/xserverrc
+exec /usr/bin/X -nolisten tcp "$@" vt${XDG_VTNR}


### PR DESCRIPTION
This should solve cases where the "tty" or "virtual console" are not properly permissioned to the user.
I'm not sure if this is a Bookworm (and possibly newer) issue, or just something randomly unlucky for me.

Note: I haven't tested the shell script edit at all, but it's a copy/paste of the xinit parts of the code... what could go wrong?

See also: https://wiki.archlinux.org/title/xinit#xserverrc

Fixes #5